### PR TITLE
Added "Already have an account" link to the sign-up page #11

### DIFF
--- a/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
+++ b/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
@@ -147,6 +147,9 @@ export default function SignupPage() {
               <div className="spinner-border" style={{height:"20px",width:"20px"}}></div>       
             )}
           </button>
+          <div>
+            Already have an account? <a href = "/login">Login</a>
+          </div>
           <div className="or">or</div>
           <div className="google-signup-btn" onClick={googlelogin}>
             continue with Google

--- a/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
+++ b/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./Signup.css";
 import googleicon from "../../Assets/google-icon.svg";
 import SidebarImage from "../../Assets/SidebarImageSignup.jpg";
-import { useNavigate } from "react-router-dom";
+import {Link, useNavigate} from "react-router-dom";
 import { useGoogleLogin } from "@react-oauth/google";
 import axios from 'axios';
 import Cookies from 'js-cookie';

--- a/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
+++ b/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
@@ -148,7 +148,7 @@ export default function SignupPage() {
             )}
           </button>
           <div>
-            Already have an account? <a href = "/login">Log in</a>
+            Already have an account? <a href = "/login">log in</a>
           </div>
           <div className="or">or</div>
           <div className="google-signup-btn" onClick={googlelogin}>

--- a/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
+++ b/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
@@ -148,7 +148,7 @@ export default function SignupPage() {
             )}
           </button>
           <div>
-            Already have an account? <a href = "/login">Login</a>
+            Already have an account? <a href = "/login">Log in</a>
           </div>
           <div className="or">or</div>
           <div className="google-signup-btn" onClick={googlelogin}>

--- a/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
+++ b/linkup-frontend/src/Pages/SignupPage/SignupPage.jsx
@@ -148,7 +148,7 @@ export default function SignupPage() {
             )}
           </button>
           <div>
-            Already have an account? <a href = "/login">log in</a>
+            Already have an account <Link to={'/login'}>log in</Link>
           </div>
           <div className="or">or</div>
           <div className="google-signup-btn" onClick={googlelogin}>


### PR DESCRIPTION
The purpose of this pull request is to add an "Already have an account" link to our sign-up page, providing users with a convenient way to navigate to the login page. This link will be placed below the sign-up form, assisting users in quickly finding the option to log in.
To achieve this goal, the following changes have been made:

- Added a new hyperlink at the bottom of the sign-up page with the text "Already have an account log in"

- Set the target URL of the link to the login page to ensure that users are redirected to the login page upon clicking the link.

The purpose of this change is to enhance the user experience and provide users with more options and flexibility during the sign-up process.
### **screen shot**

- before
![image](https://github.com/moonlight0301/LinkUp/assets/138412395/a9ba32f0-9579-4bfe-b1a4-4077ed40e3af)
- after
![image](https://github.com/arpittyagi102/LinkUp/assets/138412395/916afc0e-fecd-4b67-8345-89f697ab9bf6)
